### PR TITLE
Extract more values for v34 firmware

### DIFF
--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -369,7 +369,8 @@ class X3V34(InverterPost):
         'Battery Temperature':                   (27,  'C'),
         'Battery Remaining Capacity':            (28,  '%'),
 
-        'Total Battery Discharge Energy':        (30,  'kWh', discharge_energy),
+        'Total Battery Discharge Energy':        (30,  'kWh',
+                                                  discharge_energy),
         'Total Battery Discharge Energy Resets': (31,  ''),
         'Today\'s Battery Discharge Energy':     (113,  'kWh', div10),
         'Battery Remaining Energy':              (32,  'kWh', div10),
@@ -386,7 +387,8 @@ class X3V34(InverterPost):
         'AC Power':                              (181, 'W', to_signed),
 
         'EPS Frequency':                         (63, 'Hz', div100),
-        'EPS Total Energy':                      (110, 'kWh', eps_total_energy),
+        'EPS Total Energy':                      (110, 'kWh',
+                                                  eps_total_energy),
         'EPS Total Energy Resets':               (111, 'Hz'),
     }
 

--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -7,7 +7,8 @@ from voluptuous import Invalid, MultipleInvalid
 from voluptuous.humanize import humanize_error
 from solax.utils import (
     div10, div100, feedin_energy, total_energy, charge_energy, pv_energy,
-    discharge_energy, consumption, twoway_div10, twoway_div100, to_signed
+    discharge_energy, consumption, twoway_div10, twoway_div100, to_signed,
+    eps_total_energy
 )
 
 
@@ -385,6 +386,8 @@ class X3V34(InverterPost):
         'AC Power':                              (181, 'W', to_signed),
 
         'EPS Frequency':                         (63, 'Hz', div100),
+        'EPS Total Energy':                      (110, 'kWh', eps_total_energy),
+        'EPS Total Energy Resets':               (111, 'Hz'),
     }
 
     @classmethod

--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -6,8 +6,8 @@ import voluptuous as vol
 from voluptuous import Invalid, MultipleInvalid
 from voluptuous.humanize import humanize_error
 from solax.utils import (
-    div10, div100, feedin_energy, total_energy,
-    consumption, twoway_div10, twoway_div100, to_signed
+    div10, div100, feedin_energy, total_energy, charge_energy, pv_energy,
+    discharge_energy, consumption, twoway_div10, twoway_div100, to_signed
 )
 
 
@@ -331,46 +331,58 @@ class X3V34(InverterPost):
     }, extra=vol.REMOVE_EXTRA)
 
     __sensor_map = {
-        'Network Voltage Phase 1':     (0,   'V', div10),
-        'Network Voltage Phase 2':     (1,   'V', div10),
-        'Network Voltage Phase 3':     (2,   'V', div10),
+        'Network Voltage Phase 1':               (0,   'V', div10),
+        'Network Voltage Phase 2':               (1,   'V', div10),
+        'Network Voltage Phase 3':               (2,   'V', div10),
 
-        'Output Current Phase 1':      (3,   'A', twoway_div10),
-        'Output Current Phase 2':      (4,   'A', twoway_div10),
-        'Output Current Phase 3':      (5,   'A', twoway_div10),
+        'Output Current Phase 1':                (3,   'A', twoway_div10),
+        'Output Current Phase 2':                (4,   'A', twoway_div10),
+        'Output Current Phase 3':                (5,   'A', twoway_div10),
 
-        'Power Now Phase 1':           (6,   'W', to_signed),
-        'Power Now Phase 2':           (7,   'W', to_signed),
-        'Power Now Phase 3':           (8,   'W', to_signed),
+        'Power Now Phase 1':                     (6,   'W', to_signed),
+        'Power Now Phase 2':                     (7,   'W', to_signed),
+        'Power Now Phase 3':                     (8,   'W', to_signed),
 
-        'PV1 Voltage':                 (9,   'V', div10),
-        'PV2 Voltage':                 (10,  'V', div10),
-        'PV1 Current':                 (11,  'A', div10),
-        'PV2 Current':                 (12,  'A', div10),
-        'PV1 Power':                   (13,  'W'),
-        'PV2 Power':                   (14,  'W'),
+        'PV1 Voltage':                           (9,   'V', div10),
+        'PV2 Voltage':                           (10,  'V', div10),
+        'PV1 Current':                           (11,  'A', div10),
+        'PV2 Current':                           (12,  'A', div10),
+        'PV1 Power':                             (13,  'W'),
+        'PV2 Power':                             (14,  'W'),
 
-        'Grid Frequency Phase 1':      (15,  'Hz', div100),
-        'Grid Frequency Phase 2':      (16,  'Hz', div100),
-        'Grid Frequency Phase 3':      (17,  'Hz', div100),
+        'Total PV Energy':                       (89,  'kWh', pv_energy),
+        'Total PV Energy Resets':                (90,  ''),
+        'Today\'s PV Energy':                    (112,  'kWh', div10),
 
-        'Total Energy':                (19,  'kWh', total_energy),
-        'Total Energy Resets':         (20,  ''),
-        'Today\'s Energy':             (21,  'kWh', div10),
+        'Grid Frequency Phase 1':                (15,  'Hz', div100),
+        'Grid Frequency Phase 2':                (16,  'Hz', div100),
+        'Grid Frequency Phase 3':                (17,  'Hz', div100),
 
-        'Battery Voltage':             (24,  'V', div100),
-        'Battery Current':             (25,  'A', twoway_div100),
-        'Battery Power':               (26,  'W', to_signed),
-        'Battery Temperature':         (27,  'C'),
-        'Battery Remaining Capacity':  (28,  '%'),
+        'Total Energy':                          (19,  'kWh', total_energy),
+        'Total Energy Resets':                   (20,  ''),
+        'Today\'s Energy':                       (21,  'kWh', div10),
 
-        'Exported Power':              (65,  'W', to_signed),
-        'Total Feed-in Energy':        (67,  'kWh', feedin_energy),
-        'Total Feed-in Energy Resets': (68,  ''),
-        'Total Consumption':           (69,  'kWh', consumption),
-        'Total Consumption Resets':    (70,  ''),
+        'Battery Voltage':                       (24,  'V', div100),
+        'Battery Current':                       (25,  'A', twoway_div100),
+        'Battery Power':                         (26,  'W', to_signed),
+        'Battery Temperature':                   (27,  'C'),
+        'Battery Remaining Capacity':            (28,  '%'),
 
-        'AC Power':                    (181, 'W', to_signed),
+        'Total Battery Discharge Energy':        (30,  'kWh', discharge_energy),
+        'Total Battery Discharge Energy Resets': (31,  ''),
+        'Today\'s Battery Discharge Energy':     (113,  'kWh', div10),
+        'Battery Remaining Energy':              (32,  'kWh', div10),
+        'Total Battery Charge Energy':           (87,  'kWh', charge_energy),
+        'Total Battery Charge Energy Resets':    (88,  ''),
+        'Today\'s Battery Charge Energy':        (114,  'kWh', div10),
+
+        'Exported Power':                        (65,  'W', to_signed),
+        'Total Feed-in Energy':                  (67,  'kWh', feedin_energy),
+        'Total Feed-in Energy Resets':           (68,  ''),
+        'Total Consumption':                     (69,  'kWh', consumption),
+        'Total Consumption Resets':              (70,  ''),
+
+        'AC Power':                              (181, 'W', to_signed),
     }
 
     @classmethod

--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from voluptuous import Invalid, MultipleInvalid
 from voluptuous.humanize import humanize_error
 from solax.utils import (
-    div10, div100, energy,
+    div10, div100, feedin_energy, total_energy,
     consumption, twoway_div10, twoway_div100, to_signed
 )
 
@@ -354,7 +354,8 @@ class X3V34(InverterPost):
         'Grid Frequency Phase 2':      (16,  'Hz', div100),
         'Grid Frequency Phase 3':      (17,  'Hz', div100),
 
-        'Total Energy':                (19,  'kWh', div10),
+        'Total Energy':                (19,  'kWh', total_energy),
+        'Total Energy Resets':         (20,  ''),
         'Today\'s Energy':             (21,  'kWh', div10),
 
         'Battery Voltage':             (24,  'V', div100),
@@ -364,7 +365,7 @@ class X3V34(InverterPost):
         'Battery Remaining Capacity':  (28,  '%'),
 
         'Exported Power':              (65,  'W', to_signed),
-        'Total Feed-in Energy':        (67,  'kWh', energy),
+        'Total Feed-in Energy':        (67,  'kWh', feedin_energy),
         'Total Feed-in Energy Resets': (68,  ''),
         'Total Consumption':           (69,  'kWh', consumption),
         'Total Consumption Resets':    (70,  ''),

--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -383,6 +383,8 @@ class X3V34(InverterPost):
         'Total Consumption Resets':              (70,  ''),
 
         'AC Power':                              (181, 'W', to_signed),
+
+        'EPS Frequency':                         (63, 'Hz', div100),
     }
 
     @classmethod

--- a/solax/utils.py
+++ b/solax/utils.py
@@ -6,7 +6,8 @@ def div100(val, *_args, **_kwargs):
     return val / 100
 
 
-def resetting_counter(value, mapped_sensor_data, key, adjust, *_args, **_kwargs):
+def resetting_counter(value, mapped_sensor_data, key, adjust,
+                      *_args, **_kwargs):
     value += mapped_sensor_data[key] * 65535
     value = adjust(value)
     return value

--- a/solax/utils.py
+++ b/solax/utils.py
@@ -22,6 +22,24 @@ def feedin_energy(value, mapped_sensor_data, *_args, **_kwargs):
                              key='Total Feed-in Energy Resets', adjust=div100)
 
 
+def charge_energy(value, mapped_sensor_data, *_args, **_kwargs):
+    return resetting_counter(value, mapped_sensor_data,
+                             key='Total Battery Charge Energy Resets',
+                             adjust=div10)
+
+
+def discharge_energy(value, mapped_sensor_data, *_args, **_kwargs):
+    return resetting_counter(value, mapped_sensor_data,
+                             key='Total Battery Discharge Energy Resets',
+                             adjust=div10)
+
+
+def pv_energy(value, mapped_sensor_data, *_args, **_kwargs):
+    return resetting_counter(value, mapped_sensor_data,
+                             key='Total PV Energy Resets',
+                             adjust=div10)
+
+
 def consumption(value, mapped_sensor_data, *_args, **_kwargs):
     return resetting_counter(value, mapped_sensor_data,
                              key='Total Consumption Resets', adjust=div100)

--- a/solax/utils.py
+++ b/solax/utils.py
@@ -17,6 +17,11 @@ def total_energy(value, mapped_sensor_data, *_args, **_kwargs):
                              key='Total Energy Resets', adjust=div10)
 
 
+def eps_total_energy(value, mapped_sensor_data, *_args, **_kwargs):
+    return resetting_counter(value, mapped_sensor_data,
+                             key='EPS Total Energy Resets', adjust=div10)
+
+
 def feedin_energy(value, mapped_sensor_data, *_args, **_kwargs):
     return resetting_counter(value, mapped_sensor_data,
                              key='Total Feed-in Energy Resets', adjust=div100)

--- a/solax/utils.py
+++ b/solax/utils.py
@@ -6,16 +6,25 @@ def div100(val, *_args, **_kwargs):
     return val / 100
 
 
-def energy(value, mapped_sensor_data, *_args, **_kwargs):
-    value += mapped_sensor_data['Total Feed-in Energy Resets'] * 65535
-    value = value / 100
+def resetting_counter(value, mapped_sensor_data, key, adjust, *_args, **_kwargs):
+    value += mapped_sensor_data[key] * 65535
+    value = adjust(value)
     return value
+
+
+def total_energy(value, mapped_sensor_data, *_args, **_kwargs):
+    return resetting_counter(value, mapped_sensor_data,
+                             key='Total Energy Resets', adjust=div10)
+
+
+def feedin_energy(value, mapped_sensor_data, *_args, **_kwargs):
+    return resetting_counter(value, mapped_sensor_data,
+                             key='Total Feed-in Energy Resets', adjust=div100)
 
 
 def consumption(value, mapped_sensor_data, *_args, **_kwargs):
-    value += mapped_sensor_data['Total Consumption Resets'] * 65535
-    value = value / 100
-    return value
+    return resetting_counter(value, mapped_sensor_data,
+                             key='Total Consumption Resets', adjust=div100)
 
 
 def to_signed(val, *_args, **_kwargs):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -368,6 +368,10 @@ X3V34_HYBRID_VALUES = {
     'PV1 Power': 958,
     'PV2 Power': 0,
 
+    'Total PV Energy': 1731.9,
+    'Total PV Energy Resets': 0,
+    'Today\'s PV Energy': 16.4,
+
     'Grid Frequency Phase 1': 50.03,
     'Grid Frequency Phase 2': 50.03,
     'Grid Frequency Phase 3': 50.03,
@@ -381,6 +385,14 @@ X3V34_HYBRID_VALUES = {
     'Battery Power': 229,
     'Battery Temperature': 22,
     'Battery Remaining Capacity': 99,
+
+    'Total Battery Discharge Energy': 706.2,
+    'Total Battery Discharge Energy Resets': 0,
+    'Today\'s Battery Discharge Energy': 4.3,
+    'Battery Remaining Energy': 12.5,
+    'Total Battery Charge Energy': 814.2,
+    'Total Battery Charge Energy Resets': 0,
+    'Today\'s Battery Charge Energy': 9.1,
 
     'Exported Power': -55,
     'Total Feed-in Energy': 173.72,
@@ -411,6 +423,10 @@ X3V34_HYBRID_VALUES_NEGATIVE_POWER = {
     'PV1 Power': 0,
     'PV2 Power': 0,
 
+    'Total PV Energy': 9615.1,
+    'Total PV Energy Resets': 1,
+    'Today\'s PV Energy': 9.8,
+
     'Grid Frequency Phase 1': 49.98,
     'Grid Frequency Phase 2': 49.98,
     'Grid Frequency Phase 3': 49.98,
@@ -424,6 +440,14 @@ X3V34_HYBRID_VALUES_NEGATIVE_POWER = {
     'Battery Power': 5117,
     'Battery Temperature': 24,
     'Battery Remaining Capacity': 20,
+
+    'Total Battery Discharge Energy': 2469.6,
+    'Total Battery Discharge Energy Resets': 0,
+    'Today\'s Battery Discharge Energy': 4,
+    'Battery Remaining Energy': 2.6,
+    'Total Battery Charge Energy': 2887.6,
+    'Total Battery Charge Energy Resets': 0,
+    'Today\'s Battery Charge Energy': 6,
 
     'Exported Power': -5743,
     'Total Feed-in Energy': 3593.49,
@@ -454,6 +478,10 @@ X3V34_HYBRID_VALUES_EPS_MODE = {
     'PV1 Power': 2678,
     'PV2 Power': 0,
 
+    'Total PV Energy': 8378.7,
+    'Total PV Energy Resets': 1,
+    'Today\'s PV Energy': 26,
+
     'Grid Frequency Phase 1': 0,
     'Grid Frequency Phase 2': 0,
     'Grid Frequency Phase 3': 0,
@@ -467,6 +495,14 @@ X3V34_HYBRID_VALUES_EPS_MODE = {
     'Battery Power': -241,
     'Battery Temperature': 27,
     'Battery Remaining Capacity': 98,
+
+    'Total Battery Discharge Energy': 2124,
+    'Total Battery Discharge Energy Resets': 0,
+    'Today\'s Battery Discharge Energy': 6.1,
+    'Battery Remaining Energy': 12.4,
+    'Total Battery Charge Energy': 2501.1,
+    'Total Battery Charge Energy Resets': 0,
+    'Today\'s Battery Charge Energy': 11.9,
 
     'Exported Power': 0,
     'Total Feed-in Energy': 3174.79,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -373,6 +373,7 @@ X3V34_HYBRID_VALUES = {
     'Grid Frequency Phase 3': 50.03,
 
     'Total Energy': 1483.3,
+    'Total Energy Resets': 0,
     'Today\'s Energy': 10.3,
 
     'Battery Voltage': 229.3,
@@ -414,7 +415,8 @@ X3V34_HYBRID_VALUES_NEGATIVE_POWER = {
     'Grid Frequency Phase 2': 49.98,
     'Grid Frequency Phase 3': 49.98,
 
-    'Total Energy': 1925.1,
+    'Total Energy': 8478.6,
+    'Total Energy Resets': 1,
     'Today\'s Energy': 8.4,
 
     'Battery Voltage': 204.6,
@@ -456,7 +458,8 @@ X3V34_HYBRID_VALUES_EPS_MODE = {
     'Grid Frequency Phase 2': 0,
     'Grid Frequency Phase 3': 0,
 
-    'Total Energy': 833.9,
+    'Total Energy': 7387.4,
+    'Total Energy Resets': 1,
     'Today\'s Energy': 17.8,
 
     'Battery Voltage': 228.6,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -239,6 +239,27 @@ X3_HYBRID_G3_2X_MPPT_RESPONSE_V34_NEGATIVE_POWER = {
     "Information": [8.000, 5, "XXXXXXXX", 1, 4.60, 0.00, 4.42, 1.05, 0.00, 1]
 }
 
+X3_HYBRID_G3_2X_MPPT_RESPONSE_V34_EPS_MODE = {
+    "type": 5,
+    "sn": "XXXXXXXXXX",
+    "ver": "2.034.06",
+    "Data": [0, 0, 0, 0, 0, 0, 0, 0, 0, 4864, 4466, 55, 0, 2678, 0, 0, 0, 0, 7,
+             8339, 1, 178, 0, 0, 22860, 65436, 65294, 27, 98, 0, 21240, 0, 124,
+             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 0, 52, 7541, 226,
+             2453, 205, 2223, 2276, 2426, 10, 107, 8, 172, 2441, 147, 5000, 0,
+             0, 0, 55339, 4, 18922, 1, 0, 52, 256, 2352, 1568, 0, 350, 275,
+             262, 41, 41, 225, 1, 1, 0, 0, 25011, 0, 18252, 1, 17, 0, 0, 0, 0,
+             0, 0, 0, 0, 0, 0, 0, 0, 0, 768, 0, 54, 0, 2, 17, 0, 260, 61, 119,
+             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 256, 7971, 6926, 5385, 1107, 512,
+             8224, 8224, 0, 0, 4369, 0, 273, 2288, 65523, 65239, 4099, 4083,
+             13728, 87, 21302, 19778, 18003, 12355, 16697, 12354, 14132, 21302,
+             13110, 12338, 12337, 14386, 12354, 12852, 21302, 13110, 12338,
+             12337, 14386, 12354, 12340, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+             0, 0, 1, 257, 257, 1281, 1025, 0, 22860, 0, 0, 0, 0, 0, 0, 0, 0,
+             0, 0, 0],
+    "Information": [8.000, 5, "XXXXXXXX", 1, 4.60, 0.00, 4.42, 1.05, 0.00, 1]
+}
+
 X3_VALUES = {
     'PV1 Current': 0,
     'PV2 Current': 1,
@@ -409,6 +430,48 @@ X3V34_HYBRID_VALUES_NEGATIVE_POWER = {
     'Total Consumption Resets': 1,
 
     'AC Power': -5233,
+}
+
+X3V34_HYBRID_VALUES_EPS_MODE = {
+    'Network Voltage Phase 1': 0,
+    'Network Voltage Phase 2': 0,
+    'Network Voltage Phase 3': 0,
+
+    'Output Current Phase 1': 0,
+    'Output Current Phase 2': 0,
+    'Output Current Phase 3': 0,
+
+    'Power Now Phase 1': 0,
+    'Power Now Phase 2': 0,
+    'Power Now Phase 3': 0,
+
+    'PV1 Voltage': 486.4,
+    'PV2 Voltage': 446.6,
+    'PV1 Current': 5.5,
+    'PV2 Current': 0,
+    'PV1 Power': 2678,
+    'PV2 Power': 0,
+
+    'Grid Frequency Phase 1': 0,
+    'Grid Frequency Phase 2': 0,
+    'Grid Frequency Phase 3': 0,
+
+    'Total Energy': 833.9,
+    'Today\'s Energy': 17.8,
+
+    'Battery Voltage': 228.6,
+    'Battery Current': -0.99,
+    'Battery Power': -241,
+    'Battery Temperature': 27,
+    'Battery Remaining Capacity': 98,
+
+    'Exported Power': 0,
+    'Total Feed-in Energy': 3174.79,
+    'Total Feed-in Energy Resets': 4,
+    'Total Consumption': 844.57,
+    'Total Consumption Resets': 1,
+
+    'AC Power': 0,
 }
 
 X1_VALUES = {
@@ -592,6 +655,14 @@ INVERTERS_UNDER_TEST = [
         response=X3_HYBRID_G3_2X_MPPT_RESPONSE_V34_NEGATIVE_POWER,
         inverter=inverter.X3V34,
         values=X3V34_HYBRID_VALUES_NEGATIVE_POWER,
+    ),
+    InverterUnderTest(
+        uri="/",
+        method='POST',
+        query_string='optType=ReadRealTimeData',
+        response=X3_HYBRID_G3_2X_MPPT_RESPONSE_V34_EPS_MODE,
+        inverter=inverter.X3V34,
+        values=X3V34_HYBRID_VALUES_EPS_MODE,
     )
 ]
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -403,6 +403,8 @@ X3V34_HYBRID_VALUES = {
     'AC Power': 686,
 
     'EPS Frequency': 0,
+    'EPS Total Energy': 0.6,
+    'EPS Total Energy Resets': 0,
 }
 
 X3V34_HYBRID_VALUES_NEGATIVE_POWER = {
@@ -460,6 +462,8 @@ X3V34_HYBRID_VALUES_NEGATIVE_POWER = {
     'AC Power': -5233,
 
     'EPS Frequency': 0,
+    'EPS Total Energy': 2.1,
+    'EPS Total Energy Resets': 0,
 }
 
 X3V34_HYBRID_VALUES_EPS_MODE = {
@@ -517,6 +521,8 @@ X3V34_HYBRID_VALUES_EPS_MODE = {
     'AC Power': 0,
 
     'EPS Frequency': 50,
+    'EPS Total Energy': 1.7,
+    'EPS Total Energy Resets': 0,
 }
 
 X1_VALUES = {

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -401,6 +401,8 @@ X3V34_HYBRID_VALUES = {
     'Total Consumption Resets': 0,
 
     'AC Power': 686,
+
+    'EPS Frequency': 0,
 }
 
 X3V34_HYBRID_VALUES_NEGATIVE_POWER = {
@@ -456,6 +458,8 @@ X3V34_HYBRID_VALUES_NEGATIVE_POWER = {
     'Total Consumption Resets': 1,
 
     'AC Power': -5233,
+
+    'EPS Frequency': 0,
 }
 
 X3V34_HYBRID_VALUES_EPS_MODE = {
@@ -511,6 +515,8 @@ X3V34_HYBRID_VALUES_EPS_MODE = {
     'Total Consumption Resets': 1,
 
     'AC Power': 0,
+
+    'EPS Frequency': 50,
 }
 
 X1_VALUES = {

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -15,7 +15,8 @@ async def test_smoke(inverters_fixture):
     msg = 'data size should match expected values'
     assert len(values) == len(parsed.data), msg
     for sensor, value in values.items():
-        assert parsed.data[sensor] == value, f"{sensor}: expected {value} but got {parsed.data[sensor]}"
+        assert parsed.data[sensor] == value, \
+          f"{sensor}: expected {value} but got {parsed.data[sensor]}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -15,7 +15,7 @@ async def test_smoke(inverters_fixture):
     msg = 'data size should match expected values'
     assert len(values) == len(parsed.data), msg
     for sensor, value in values.items():
-        assert parsed.data[sensor] == value
+        assert parsed.data[sensor] == value, f"{sensor}: expected {value} but got {parsed.data[sensor]}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Added:
  * EPS yield and frequency (still a couple others missing)
  * daily and total energy counters for PV yield, battery charge, and battery discharge
  * battery stored energy
  * reset counter for total energy (otherwise the data is wrong after the inverter passes 655.35kWh of yield)