### PR TITLE
add manufacturer information

### DIFF
--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -27,6 +27,7 @@ class Inverter:
         self.host = host
         self.port = port
         self.pwd = pwd
+        self.manufacturer = "Solax"
 
     async def get_data(self):
         try:

--- a/solax/inverters/qvolt_hyb_g3_3p.py
+++ b/solax/inverters/qvolt_hyb_g3_3p.py
@@ -40,6 +40,10 @@ class QVOLTHYBG33P(InverterPost):
                 3: "Feed-in Priority",
             }.get(value, f"unmapped value '{value}'")
 
+    def __init__(self, host, port, pwd=''):
+        super().__init__(host, port, pwd)
+        self.manufacturer = "Qcells"
+
     _schema = vol.Schema({
         vol.Required('type'): vol.All(int, 14),
         vol.Required('sn'): str,


### PR DESCRIPTION
In order to be able to differentiate between Solax and Qcells this PR will add a property which contains the manufacturer.

This can later be used in the home assistant integration to setup the sensors with the proper manufacturer.
