### PR TITLE
Support Multiple inverter api for inverter type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.vscode
+/.idea/**
 *.pyc
 /dist
 /solax.egg-info

--- a/solax/discovery.py
+++ b/solax/discovery.py
@@ -34,12 +34,12 @@ class DiscoveryError(Exception):
 async def discover(host, port, pwd="") -> Inverter:
     failures = []
     for inverter in REGISTRY:
-        i = inverter(host, port, pwd)
-        try:
-            await i.get_data()
-            return i
-        except InverterError as ex:
-            failures.append(ex)
+        for i in inverter.build_all_variants(host, port, pwd):
+            try:
+                await i.get_data()
+                return i
+            except InverterError as ex:
+                failures.append(ex)
     msg = (
         "Unable to connect to the inverter at "
         f"host={host} port={port}, or your inverter is not supported yet.\n"

--- a/solax/inverter_http_client.py
+++ b/solax/inverter_http_client.py
@@ -1,0 +1,73 @@
+from enum import Enum
+
+import aiohttp
+
+
+class Method(Enum):
+    GET = 1
+    POST = 2
+
+
+class InverterHttpClient:
+    def __init__(self, url, method: Method = Method.POST, pwd=""):
+        """Initialize the Http client."""
+        self.url = url
+        self.method = method
+        self.pwd = pwd
+        self.headers = None
+        self.data = None
+        self.query = ""
+
+    @classmethod
+    def build_w_url(cls, url, method: Method = Method.POST):
+        http_client = cls(url, method, "")
+        return http_client
+
+    def with_headers(self, headers):
+        self.headers = headers
+        return self
+
+    def with_default_data(self):
+        data = "optType=ReadRealTimeData"
+        if self.pwd:
+            data = data + "&pwd=" + self.pwd
+        return self.with_data(data)
+
+    def with_data(self, data):
+        self.data = data
+        return self
+
+    def with_query(self, query):
+        self.query = query
+        return self
+
+    def with_default_query(self):
+        if self.pwd:
+            base = "optType=ReadRealTimeData&pwd={}&"
+            query = base.format(self.pwd)
+        else:
+            query = "optType=ReadRealTimeData"
+
+        return self.with_query(query)
+
+    async def request(self):
+        if self.method is Method.POST:
+            return await self.post()
+        return await self.get()
+
+    async def get(self):
+        url = self.url + "?" + self.query if self.query else self.url
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=self.headers) as req:
+                req.raise_for_status()
+                resp = await req.read()
+        return resp
+
+    async def post(self):
+        url = self.url + "?" + self.query if self.query else self.url
+        data = self.data.encode("utf-8") if self.data else None
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=self.headers, data=data) as req:
+                req.raise_for_status()
+                resp = await req.read()
+        return resp

--- a/solax/inverters/qvolt_hyb_g3_3p.py
+++ b/solax/inverters/qvolt_hyb_g3_3p.py
@@ -1,6 +1,6 @@
 import voluptuous as vol
-import aiohttp
-from solax.inverter import InverterPost
+from solax import utils
+from solax.inverter import Inverter, InverterHttpClient, Method, ResponseParser
 from solax.units import Total, Units
 from solax.utils import (
     div10,
@@ -12,7 +12,7 @@ from solax.utils import (
 )
 
 
-class QVOLTHYBG33P(InverterPost):
+class QVOLTHYBG33P(Inverter):
     """
     QCells
     Q.VOLT HYB-G3-3P
@@ -48,8 +48,10 @@ class QVOLTHYBG33P(InverterPost):
                 3: "Feed-in Priority",
             }.get(value, f"unmapped value '{value}'")
 
-    def __init__(self, host, port, pwd=""):
-        super().__init__(host, port, pwd)
+    def __init__(
+        self, http_client: InverterHttpClient, response_parser: ResponseParser
+    ):
+        super().__init__(http_client, response_parser)
         self.manufacturer = "Qcells"
 
     _schema = vol.Schema(
@@ -165,13 +167,16 @@ class QVOLTHYBG33P(InverterPost):
         }
 
     @classmethod
-    async def make_request(cls, host, port=80, pwd="", headers=None):
+    def _build(cls, host, port, pwd="", params_in_query=True):
+        url = utils.to_url(host, port)
+        http_client = InverterHttpClient(url, Method.POST, pwd).with_default_data()
 
-        url = f"http://{host}:{port}/"
-        data = f"optType=ReadRealTimeData&pwd={pwd}"
+        schema = cls._schema
+        response_decoder = cls.response_decoder()
+        response_parser = ResponseParser(schema, response_decoder)
+        return cls(http_client, response_parser)
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, data=data) as req:
-                resp = await req.read()
-
-        return cls.handle_response(resp)
+    @classmethod
+    def build_all_variants(cls, host, port, pwd=""):
+        versions = [cls._build(host, port, pwd)]
+        return versions

--- a/solax/inverters/x1.py
+++ b/solax/inverters/x1.py
@@ -1,10 +1,10 @@
 import voluptuous as vol
-from solax.inverter import InverterPost
+from solax.inverter import Inverter
 from solax.units import Units, Total
 from solax.utils import startswith
 
 
-class X1(InverterPost):
+class X1(Inverter):
     # pylint: disable=duplicate-code
     _schema = vol.Schema(
         {

--- a/solax/inverters/x1_boost.py
+++ b/solax/inverters/x1_boost.py
@@ -1,10 +1,11 @@
 import voluptuous as vol
-from solax.inverter import InverterPost
+from solax import utils
+from solax.inverter import Inverter, InverterHttpClient, Method, ResponseParser
 from solax.units import Units, Total
 from solax.utils import div10, div100, to_signed
 
 
-class X1Boost(InverterPost):
+class X1Boost(Inverter):
     """
     X1-Boost with Pocket WiFi 2.034.06
     Includes X-Forwarded-For for direct LAN API access
@@ -53,6 +54,25 @@ class X1Boost(InverterPost):
         }
 
     @classmethod
-    async def make_request(cls, host, port=80, pwd="", headers=None):
+    def _build(cls, host, port, pwd="", params_in_query=True):
+        url = utils.to_url(host, port)
+        http_client = InverterHttpClient(url, Method.POST, pwd)
+        if params_in_query:
+            http_client.with_default_query()
+        else:
+            http_client.with_default_data()
+
         headers = {"X-Forwarded-For": "5.8.8.8"}
-        return await super().make_request(host, port, pwd, headers=headers)
+        http_client.with_headers(headers)
+        schema = cls._schema
+        response_decoder = cls.response_decoder()
+        response_parser = ResponseParser(schema, response_decoder)
+        return cls(http_client, response_parser)
+
+    @classmethod
+    def build_all_variants(cls, host, port, pwd=""):
+        versions = [
+            cls._build(host, port, pwd, True),
+            cls._build(host, port, pwd, False),
+        ]
+        return versions

--- a/solax/inverters/x1_hybrid_gen4.py
+++ b/solax/inverters/x1_hybrid_gen4.py
@@ -1,10 +1,11 @@
 import voluptuous as vol
-from solax.inverter import InverterPostData
+from solax import utils
+from solax.inverter import Inverter, InverterHttpClient, Method, ResponseParser
 from solax.units import Units, Total
 from solax.utils import div10, div100, pack_u16, to_signed
 
 
-class X1HybridGen4(InverterPostData):
+class X1HybridGen4(Inverter):
     # pylint: disable=duplicate-code
     _schema = vol.Schema(
         {
@@ -23,6 +24,19 @@ class X1HybridGen4(InverterPostData):
         },
         extra=vol.REMOVE_EXTRA,
     )
+
+    @classmethod
+    def _build(cls, host, port, pwd="", params_in_query=True):
+        url = utils.to_url(host, port)
+        http_client = InverterHttpClient(url, Method.POST, pwd).with_default_data()
+
+        response_parser = ResponseParser(cls._schema, cls.response_decoder())
+        return cls(http_client, response_parser)
+
+    @classmethod
+    def build_all_variants(cls, host, port, pwd=""):
+        versions = [cls._build(host, port, pwd)]
+        return versions
 
     @classmethod
     def response_decoder(cls):

--- a/solax/inverters/x1_mini.py
+++ b/solax/inverters/x1_mini.py
@@ -1,10 +1,10 @@
 import voluptuous as vol
-from solax.inverter import InverterPost
+from solax.inverter import Inverter
 from solax.units import Total, Units
 from solax.utils import startswith
 
 
-class X1Mini(InverterPost):
+class X1Mini(Inverter):
     # pylint: disable=duplicate-code
     _schema = vol.Schema(
         {

--- a/solax/inverters/x1_mini_v34.py
+++ b/solax/inverters/x1_mini_v34.py
@@ -1,11 +1,11 @@
 import voluptuous as vol
 
-from solax.inverter import InverterPost
+from solax.inverter import Inverter
 from solax.units import Units, Total
 from solax.utils import div10, div100
 
 
-class X1MiniV34(InverterPost):
+class X1MiniV34(Inverter):
     """
     X1-Boost-Air-Mini with Wifi Pocket v2.034.06
     SolarX disabled lan access with this custom

--- a/solax/inverters/x1_smart.py
+++ b/solax/inverters/x1_smart.py
@@ -1,10 +1,11 @@
 import voluptuous as vol
-from solax.inverter import InverterPost
+from solax import utils
+from solax.inverter import Inverter, InverterHttpClient, Method, ResponseParser
 from solax.units import Total, Units
 from solax.utils import div10, div100, to_signed
 
 
-class X1Smart(InverterPost):
+class X1Smart(Inverter):
     """
     X1-Smart with Pocket WiFi v2.033.20
     Includes X-Forwarded-For for direct LAN API access
@@ -51,6 +52,25 @@ class X1Smart(InverterPost):
         }
 
     @classmethod
-    async def make_request(cls, host, port=80, pwd="", headers=None):
+    def _build(cls, host, port, pwd="", params_in_query=True):
+        url = utils.to_url(host, port)
+        http_client = InverterHttpClient(url, Method.POST, pwd)
+        if params_in_query:
+            http_client.with_default_query()
+        else:
+            http_client.with_default_data()
+
         headers = {"X-Forwarded-For": "5.8.8.8"}
-        return await super().make_request(host, port, pwd, headers=headers)
+        http_client.with_headers(headers)
+        schema = cls._schema
+        response_decoder = cls.response_decoder()
+        response_parser = ResponseParser(schema, response_decoder)
+        return cls(http_client, response_parser)
+
+    @classmethod
+    def build_all_variants(cls, host, port, pwd=""):
+        versions = [
+            cls._build(host, port, pwd, True),
+            cls._build(host, port, pwd, False),
+        ]
+        return versions

--- a/solax/inverters/x3.py
+++ b/solax/inverters/x3.py
@@ -1,10 +1,10 @@
 import voluptuous as vol
-from solax.inverter import InverterPost
+from solax.inverter import Inverter
 from solax.units import Units, Total
 from solax.utils import startswith
 
 
-class X3(InverterPost):
+class X3(Inverter):
     _schema = vol.Schema(
         {
             vol.Required("type"): vol.All(str, startswith("X3-")),

--- a/solax/inverters/x3_v34.py
+++ b/solax/inverters/x3_v34.py
@@ -1,5 +1,5 @@
 import voluptuous as vol
-from solax.inverter import InverterPost
+from solax.inverter import Inverter
 from solax.units import Total, Units
 from solax.utils import (
     div10,
@@ -11,7 +11,7 @@ from solax.utils import (
 )
 
 
-class X3V34(InverterPost):
+class X3V34(Inverter):
     """X3 v2.034.06"""
 
     # pylint: disable=duplicate-code

--- a/solax/inverters/x_hybrid.py
+++ b/solax/inverters/x_hybrid.py
@@ -1,7 +1,6 @@
-import json
-import aiohttp
 import voluptuous as vol
-from solax.inverter import Inverter, InverterResponse
+
+from solax.inverter import Inverter, InverterHttpClient, Method, ResponseParser
 from solax.units import Total, Units
 
 
@@ -27,6 +26,19 @@ class XHybrid(Inverter):
         },
         extra=vol.REMOVE_EXTRA,
     )
+
+    @classmethod
+    def _build(cls, host, port, pwd="", params_in_query=True):
+        base = "http://{}:{}/api/realTimeData.htm"
+        url = base.format(host, port)
+        http_client = InverterHttpClient.build_w_url(url, Method.GET)
+        response_parser = ResponseParser(cls._schema, cls.response_decoder())
+        return cls(http_client, response_parser)
+
+    @classmethod
+    def build_all_variants(cls, host, port, pwd=""):
+        versions = [cls._build(host, port)]
+        return versions
 
     # key: name of sensor
     # value.0: index
@@ -60,21 +72,3 @@ class XHybrid(Inverter):
             "EPS Power": (55, Units.W),
             "EPS Frequency": (56, Units.HZ),
         }
-
-    @classmethod
-    async def make_request(cls, host, port=80, pwd="", headers=None):
-        base = "http://{}:{}/api/realTimeData.htm"
-        url = base.format(host, port)
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url) as req:
-                garbage = await req.read()
-        formatted = garbage.decode("utf-8")
-        formatted = formatted.replace(",,", ",0.0,").replace(",,", ",0.0,")
-        json_response = json.loads(formatted)
-        response = cls.schema()(json_response)
-        return InverterResponse(
-            data=cls.map_response(response["Data"]),
-            serial_number=response["SN"],
-            version=response["version"],
-            type=response["type"],
-        )

--- a/solax/response_parser.py
+++ b/solax/response_parser.py
@@ -1,0 +1,89 @@
+import json
+import logging
+from collections import namedtuple
+from typing import Dict, Any, Callable, Tuple, Union
+
+import voluptuous as vol
+from voluptuous import Invalid, MultipleInvalid
+from voluptuous.humanize import humanize_error
+
+from solax.units import SensorUnit
+from solax.utils import PackerBuilderResult
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.INFO)
+
+InverterResponse = namedtuple("InverterResponse", "data, serial_number, version, type")
+
+SensorIndexSpec = Union[int, PackerBuilderResult]
+ResponseDecoder = Dict[
+    str,
+    Union[
+        Tuple[SensorIndexSpec, SensorUnit],
+        Tuple[SensorIndexSpec, SensorUnit, Callable[[Any], Any]],
+    ],
+]
+
+
+class ResponseParser:
+    def __init__(self, schema: vol.Schema, decoder: ResponseDecoder):
+        self.schema = schema
+        self.response_decoder = decoder
+
+    def _decode_map(self) -> Dict[str, SensorIndexSpec]:
+        sensors: Dict[str, SensorIndexSpec] = {}
+        for name, mapping in self.response_decoder.items():
+            sensors[name] = mapping[0]
+        return sensors
+
+    def _postprocess_map(self) -> Dict[str, Callable[[Any], Any]]:
+        """
+        Return map of functions to be applied to each sensor value
+        """
+        sensors: Dict[str, Callable[[Any], Any]] = {}
+        for name, mapping in self.response_decoder.items():
+            processor = None
+            (_, _, *processor) = mapping
+            if processor:
+                sensors[name] = processor[0]
+        return sensors
+
+    def map_response(self, resp_data) -> Dict[str, Any]:
+        result = {}
+        for sensor_name, decode_info in self._decode_map().items():
+            if isinstance(decode_info, (tuple, list)):
+                indexes = decode_info[0]
+                packer = decode_info[1]
+                values = tuple(resp_data[i] for i in indexes)
+                val = packer(*values)
+            else:
+                val = resp_data[decode_info]
+            result[sensor_name] = val
+        for sensor_name, processor in self._postprocess_map().items():
+            result[sensor_name] = processor(result[sensor_name])
+        return result
+
+    def handle_response(self, resp: bytearray):
+        """
+        Decode response and map array result using mapping definition.
+
+        Args:
+            resp (bytearray): The response
+
+        Returns:
+            InverterResponse: The decoded and mapped interver response.
+        """
+
+        raw_json = resp.decode("utf-8").replace(",,", ",0.0,").replace(",,", ",0.0,")
+        json_response = json.loads(raw_json)
+        try:
+            response = self.schema(json_response)
+        except (Invalid, MultipleInvalid) as ex:
+            _ = humanize_error(json_response, ex)
+            raise
+        return InverterResponse(
+            data=self.map_response(response["Data"]),
+            serial_number=response.get("SN", response.get("sn")),
+            version=response.get("ver", response.get("version")),
+            type=response["type"],
+        )

--- a/solax/utils.py
+++ b/solax/utils.py
@@ -78,3 +78,7 @@ def twoway_div10(val):
 
 def twoway_div100(val):
     return to_signed(val) / 100
+
+
+def to_url(host, port):
+    return f"http://{host}:{port}/"

--- a/tests/test_base_inverter.py
+++ b/tests/test_base_inverter.py
@@ -1,26 +1,15 @@
 import pytest
 
-from solax import inverter
 from solax.discovery import REGISTRY
-
-
-@pytest.mark.asyncio
-async def test_unimplemented_make_request():
-    with pytest.raises(NotImplementedError):
-        await inverter.Inverter.make_request("localhost", 80)
-
-
-@pytest.mark.asyncio
-async def test_unimplemented_make_request_with_pwd():
-    with pytest.raises(NotImplementedError):
-        await inverter.Inverter.make_request("localhost", 80, "pwd")
+from solax.inverter import Inverter
 
 
 def test_all_registered_inverters_inherit_from_base():
     for i in REGISTRY:
-        assert issubclass(i, inverter.Inverter)
+        assert issubclass(i, Inverter)
 
 
 def test_unimplemented_response_decoder():
     with pytest.raises(NotImplementedError):
-        inverter.Inverter.response_decoder()
+        versions = Inverter.build_all_variants("localhost", 80)
+        versions[0].response_decoder()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,15 +1,26 @@
 import pytest
 import solax
-from solax.inverter import InverterError
+from solax.inverter import InverterError, Inverter
 from solax.discovery import REGISTRY
 from solax.units import Measurement
 from tests import fixtures
 
 
+async def build_right_variant(inverter, conn) -> Inverter:
+    last_error: BaseException = BaseException("anticipating errors")
+    for i in inverter.build_all_variants(*conn):
+        try:
+            await i.get_data()
+            return i
+        except InverterError as ex:
+            last_error = ex
+    raise last_error
+
+
 @pytest.mark.asyncio
 async def test_smoke(inverters_fixture):
     conn, inverter_class, values = inverters_fixture
-    inv = inverter_class(*conn)
+    inv = await build_right_variant(inverter_class, conn)
     rt_api = solax.RealTimeAPI(inv)
     parsed = await rt_api.get_data()
 
@@ -25,7 +36,7 @@ async def test_smoke(inverters_fixture):
 async def test_throws_when_unable_to_parse(inverters_garbage_fixture):
     conn, inverter_class = inverters_garbage_fixture
     with pytest.raises(InverterError):
-        i = inverter_class(*conn)
+        i = await build_right_variant(inverter_class, conn)
         await i.get_data()
 
 

--- a/verify.sh
+++ b/verify.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env sh
+
+set -e
+
+echo "Installing Dependencies..."
+python -m pip install --upgrade pip
+python setup.py install
+pip install --upgrade flake8 pylint pytest pytest-cov pytest-asyncio pytest-httpserver black mypy
+
+echo "Running black..."
+black --check .
+
+echo "Running mypy..."
+mypy --exclude venv .
+
+echo "Running flake8..."
+flake8 --ignore=E501 solax tests
+
+echo "Running pylint..."
+pylint -d 'C0111' solax tests
+
+echo "Running pytest..."
+pytest --cov=solax --cov-fail-under=100 --cov-branch --cov-report=term-missing .


### PR DESCRIPTION
The main problem is that inverters apis are different in two ways:

- The api end point to get the data
- Some aspects of parsing the non-"data" attributes of the response (like SN, version, etc...)

Each single inverter could expose (for example) two end points in general. as in, before version x it exposes an end point with query parameters, but after version x it exposes the end point with params in the request body.

The inheritance model in the project is short handed here. As it is based on the assumption that a single inverter will always support a single api end point contract.

This patch is basically (and only for now), refactoring in favor of composition (vs. inheritance).

Each inverter class is initiated with two dependencies/components:

- InverterHttpClient
- ResponseParser

To support multiple variants for each inverter, we only build the inverter with proper variations of those dependencies.

So, After this patch, the discovery process is all about asking the inverter class to build all possible variants this inverter knows it supports. The discovery then goes on, as was before, trying to use that variant to get_data, until one variant is successful.

The patch tries as much as possible to continue providing sane and most common defaults for inveter's implementations.

At this moment, the patch does not add (or subtract) any feature/support on top of the baseline (before the patch). This is just opening the opportunity to easily add missing variants.