### PR TITLE
Optionally define unique sensor id in inverter response decoder

### DIFF
--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -85,7 +85,11 @@ class Inverter:
         for name, mapping in cls.response_decoder().items():
             unit = Measurement(Units.NONE)
 
-            (idx, unit_or_measurement, *_) = mapping
+            if isinstance(mapping, dict):
+                idx = mapping["unique_id"]
+                unit_or_measurement = mapping["decoder"][1]
+            else:
+                (idx, unit_or_measurement, *_) = mapping
 
             if isinstance(unit_or_measurement, Units):
                 unit = Measurement(unit_or_measurement)

--- a/solax/inverters/qvolt_hyb_g3_3p.py
+++ b/solax/inverters/qvolt_hyb_g3_3p.py
@@ -89,6 +89,10 @@ class QVOLTHYBG33P(Inverter):
             "Grid Frequency Phase 2": (17, Units.HZ, div100),
             "Grid Frequency Phase 3": (18, Units.HZ, div100),
             "Inverter Operation mode": (19, Units.NONE, cls.Processors.inverter_modes),
+            "Inverter Operation mode raw": {
+                "decoder": (19, Units.NONE),
+                "unique_id": 500,
+            },
             # 20 - 32: always 0
             # 33: always 1
             # instead of to_signed this is actually 34 - 35,
@@ -156,6 +160,10 @@ class QVOLTHYBG33P(Inverter):
             # 127,128 resetting counter /1000, around battery charge + discharge
             # 164,165,166 some curves
             "Battery Operation mode": (168, Units.NONE, cls.Processors.battery_modes),
+            "Battery Operation mode raw": {
+                "decoder": (168, Units.NONE),
+                "unique_id": 501,
+            }
             # 169: div100 same as [39]
             # 170-199: always 0
         }

--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -69,7 +69,10 @@ class X3HybridG4(Inverter):
             "Grid 2 Frequency": (17, Units.HZ, div100),
             "Grid 3 Frequency": (18, Units.HZ, div100),
             "Run mode": (19, Units.NONE),
-            "Run mode text": (19, Units.NONE, X3HybridG4._decode_run_mode),
+            "Run mode text": {
+                "decoder": (19, Units.NONE, X3HybridG4._decode_run_mode),
+                "unique_id": 500,
+            },
             "EPS 1 Voltage": (23, Units.W, div10),
             "EPS 2 Voltage": (24, Units.W, div10),
             "EPS 3 Voltage": (25, Units.W, div10),

--- a/solax/inverters/x3_mic_pro_g2.py
+++ b/solax/inverters/x3_mic_pro_g2.py
@@ -66,7 +66,10 @@ class X3MicProG2(Inverter):
             "Grid 1 Frequency": (18, Units.HZ, div100),
             "Grid 2 Frequency": (19, Units.HZ, div100),
             "Grid 3 Frequency": (20, Units.HZ, div100),
-            # "Run Mode": (21, Units.NONE),
+            "Run Mode Raw": {
+                "decoder": (21, Units.NONE),
+                "unique_id": 200,
+            },
             "Run Mode": (21, Units.NONE, X3MicProG2._decode_run_mode),
             "Total Yield": (pack_u16(22, 23), Total(Units.KWH), div10),
             "Daily Yield": (24, Units.KWH, div10),

--- a/solax/inverters/x3_mic_pro_g2.py
+++ b/solax/inverters/x3_mic_pro_g2.py
@@ -68,7 +68,7 @@ class X3MicProG2(Inverter):
             "Grid 3 Frequency": (20, Units.HZ, div100),
             "Run Mode Raw": {
                 "decoder": (21, Units.NONE),
-                "unique_id": 200,
+                "unique_id": 500,
             },
             "Run Mode": (21, Units.NONE, X3MicProG2._decode_run_mode),
             "Total Yield": (pack_u16(22, 23), Total(Units.KWH), div10),

--- a/solax/response_parser.py
+++ b/solax/response_parser.py
@@ -44,6 +44,8 @@ class ResponseParser:
         """
         sensors: Dict[str, Callable[[Any], Any]] = {}
         for name, mapping in self.response_decoder.items():
+            if isinstance(mapping, dict):
+                mapping = mapping["decoder"]
             processor = None
             (_, _, *processor) = mapping
             if processor:

--- a/solax/response_parser.py
+++ b/solax/response_parser.py
@@ -33,6 +33,8 @@ class ResponseParser:
     def _decode_map(self) -> Dict[str, SensorIndexSpec]:
         sensors: Dict[str, SensorIndexSpec] = {}
         for name, mapping in self.response_decoder.items():
+            if isinstance(mapping, dict):
+                mapping = mapping["decoder"]
             sensors[name] = mapping[0]
         return sensors
 

--- a/tests/samples/expected_values.py
+++ b/tests/samples/expected_values.py
@@ -288,6 +288,7 @@ X3_MICPRO_G2_VALUES = {
     "Grid 1 Frequency": 49.98,
     "Grid 2 Frequency": 49.99,
     "Grid 3 Frequency": 49.94,
+    "Run Mode Raw": 2.0,
     "Run Mode": "Normal",
     "Total Yield": 795.7,
     "Daily Yield": 20.0,

--- a/tests/samples/expected_values.py
+++ b/tests/samples/expected_values.py
@@ -424,6 +424,7 @@ QVOLTHYBG33P_VALUES = {
     "Grid Frequency Phase 2": 50.01,
     "Grid Frequency Phase 3": 50.02,
     "Inverter Operation mode": "Normal",
+    "Inverter Operation mode raw": 2.0,
     "Exported Power": -7.0,
     "Battery Voltage": 323.4,
     "Battery Current": 5.0,
@@ -444,6 +445,7 @@ QVOLTHYBG33P_VALUES = {
     "Battery Temperature": 35.0,
     "Battery Remaining Energy": 8.8,
     "Battery Operation mode": "Self Use Mode",
+    "Battery Operation mode raw": 0,
 }
 
 X1_HYBRID_G4_VALUES = {


### PR DESCRIPTION
This is a fix for #112. It allows us to optionally define the unique sensor used by Home Assistant in the inverter's response decoder:

```
"Run Mode Raw": {
    "decoder": (21, Units.NONE),
    "unique_id": 200,
},
```

I believe explicitly defining the id is better than generating an id. An id generation algorithm would always depend on some value or order of a list, tuple or dict so that there is no guarantee that the generated id will not change in the future.

@squishykid How do you think about this solution? Let me know if you have a better idea!