### PR TITLE
Reporting radiator temperature for X3 Hybrid G4

### DIFF
--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -81,6 +81,7 @@ class X3HybridG4(Inverter):
             "EPS 3 Power": (31, Units.W, to_signed),
             "Feed-in Power ": (pack_u16(34, 35), Units.W, to_signed32),
             "Battery Power": (41, Units.W, to_signed),
+            "Radiator Temperature": (54, Units.C, to_signed),
             "Yield total": (pack_u16(68, 69), Total(Units.KWH), div10),
             "Yield today": (70, Units.KWH, div10),
             "Feed-in Energy": (pack_u16(86, 87), Total(Units.KWH), div100),

--- a/tests/samples/expected_values.py
+++ b/tests/samples/expected_values.py
@@ -257,6 +257,7 @@ X3_HYBRID_G4_VALUES = {
     "EPS 3 Power": 0.0,
     "Feed-in Power ": -152.0,
     "Battery Power": 0.0,
+    "Radiator Temperature": 23.0,
     "Yield total": 4.4,
     "Yield today": 0.1,
     "Feed-in Energy": 0.0,


### PR DESCRIPTION
Discovered by comparing radiator temperature reported in "Inverter Data" graph in Solax Cloud web interface and data reported by the inverter.