### PR TITLE
Work around slow discovery procedure

### DIFF
--- a/solax/discovery.py
+++ b/solax/discovery.py
@@ -75,6 +75,7 @@ class DiscoveryState:
                 task = asyncio.create_task(self._discovery_task(i), name=f"{i}")
                 task.add_done_callback(self._task_handler)
                 self._tasks.add(task)
+                await asyncio.sleep(1)
 
         while len(self._tasks) > 0:
             logging.debug("%d discovery tasks are still running...", len(self._tasks))


### PR DESCRIPTION
The rate at which this library fires requests at inverters seems too high for the Pocket Wifi to handle, so it eventually locks up and this causes a timeout (perhaps only on inverters which are lower in the inverter list?). Fire requests at a slightly lower rate to prevent this.

I noticed there is a PR in progress which revamps the discovery procedure, but in the meantime this can be a workaround for those using the library in e.g. Home Assistant's integration.

I have tested this with a Solax X3-MIC-10K-G2 inverter and a Pocket Wifi 3.0 (firmware in UI is 3.001.02, firmware from response is 3.008.10). Lower values do not consistently fix the issue (I have tried 0.5 and 0.75).

Credit goes to @joostlek who pointed me at this workaround.