### PR TITLE
Change X3 Hybrid G4 : Yield today to "Total"

### DIFF
--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -83,7 +83,7 @@ class X3HybridG4(Inverter):
             "Battery Power": (41, Units.W, to_signed),
             "Radiator Temperature": (54, Units.C, to_signed),
             "Yield total": (pack_u16(68, 69), Total(Units.KWH), div10),
-            "Yield today": (70, Units.KWH, div10),
+            "Yield today": (70, Total(Units.KWH), div10),
             "Feed-in Energy": (pack_u16(86, 87), Total(Units.KWH), div100),
             "Consumed Energy": (pack_u16(88, 89), Total(Units.KWH), div100),
             "Battery Remaining Capacity": (103, Units.PERCENT),


### PR DESCRIPTION
HassOS reports issue with "Yield today" being of unit "KWH" but reported as "Measurement". Changing to "Total" fixes this issue.