### PR TITLE
Optional model parameter to bypass discovery

### DIFF
--- a/solax/__init__.py
+++ b/solax/__init__.py
@@ -32,7 +32,7 @@ async def rt_request(inv: Inverter, retry, t_wait=0) -> InverterResponse:
         raise
 
 
-async def real_time_api(ip_address, port=80, pwd="", model=""):
+async def real_time_api(ip_address, port=80, pwd="", model=None):
     i = await discover(ip_address, port, pwd, model)
     return RealTimeAPI(i)
 

--- a/solax/__init__.py
+++ b/solax/__init__.py
@@ -32,8 +32,8 @@ async def rt_request(inv: Inverter, retry, t_wait=0) -> InverterResponse:
         raise
 
 
-async def real_time_api(ip_address, port=80, pwd=""):
-    i = await discover(ip_address, port, pwd)
+async def real_time_api(ip_address, port=80, pwd="", model=""):
+    i = await discover(ip_address, port, pwd, model)
     return RealTimeAPI(i)
 
 

--- a/solax/discovery.py
+++ b/solax/discovery.py
@@ -102,8 +102,3 @@ async def discover(host, port, pwd="", model=None) -> Inverter:
     discover_state = DiscoveryState()
     await discover_state.discover(host, port, pwd, model)
     return discover_state.get_discovered_inverter()
-
-def get_models() -> List[str]:
-    models = list(map(lambda inverter: inverter.__name__, REGISTRY))
-    models.sort()
-    return models

--- a/solax/discovery.py
+++ b/solax/discovery.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import typing
+from typing import List
 
 from solax.inverter import Inverter, InverterError
 from solax.inverters import (
@@ -102,3 +103,9 @@ async def discover(host, port, pwd="", model=None) -> Inverter:
     discover_state = DiscoveryState()
     await discover_state.discover(host, port, pwd, model)
     return discover_state.get_discovered_inverter()
+
+
+def get_models() -> List[str]:
+    models = list(map(lambda inverter: inverter.__name__, REGISTRY))
+    models.sort()
+    return models

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -16,6 +16,7 @@ async def test_discovery_with_model(inverters_fixture):
     conn, inverter_class, _ = inverters_fixture
     rt_api = await solax.real_time_api(*conn, "", inverter_class.__name__)
     assert rt_api.inverter.__class__ == inverter_class
+    assert inverter_class.__name__ in solax.discovery.get_models()
 
 
 @pytest.mark.asyncio

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -12,6 +12,19 @@ async def test_discovery(inverters_fixture):
 
 
 @pytest.mark.asyncio
+async def test_discovery_with_model(inverters_fixture):
+    conn, inverter_class, _ = inverters_fixture
+    rt_api = await solax.real_time_api(*conn, "", inverter_class.__name__)
+    assert rt_api.inverter.__class__ == inverter_class
+
+
+@pytest.mark.asyncio
+async def test_discovery_unsupported_inverter():
+    with pytest.raises(DiscoveryError):
+        await solax.real_time_api("localhost", 2, "", "doesnotexist")
+
+
+@pytest.mark.asyncio
 async def test_discovery_no_host():
     with pytest.raises(DiscoveryError):
         await solax.real_time_api("localhost", 2)


### PR DESCRIPTION
This is another solution to the problem described here:
https://github.com/home-assistant/core/issues/66617

The other solution is in https://github.com/squishykid/solax/pull/138 and is slightly more complicated because it introduces a new entrypoint to the library.

The solution here was originally implemented in https://github.com/squishykid/solax/pull/133 by @rowinho
then modified to pass tests by @luismsousa
My modification is in the test suite to make sure coverage is 100%.

I could not modify directly one of the previous PRs, so this is yet another PR. This one passes all tests on python 3.8/3.9/3.10 on my mac. 