### PR TITLE
Fix AC Power using unsigned int

### DIFF
--- a/solax/inverters/x1_hybrid_gen4.py
+++ b/solax/inverters/x1_hybrid_gen4.py
@@ -37,7 +37,7 @@ class X1HybridGen4(Inverter):
         return {
             "AC voltage R": (0, Units.V, div10),
             "AC current": (1, Units.A, div10),
-            "AC power": (2, Units.W),
+            "AC power": (2, Units.W, to_signed),
             "Grid frequency": (3, Units.HZ, div100),
             "PV1 voltage": (4, Units.V, div10),
             "PV2 voltage": (5, Units.V, div10),


### PR DESCRIPTION
AC power should be signed to allow for negative power from inverter.  The chart of the entity shows normal positive values but then spike to 65kw (ie 2s compliment gone wrong).  This power should be signed.
![2024-04-24 23_21_55-History – Home Assistant](https://github.com/squishykid/solax/assets/4350813/4f4c4253-afc2-4b2f-9602-a175ab4837db)
