### PR TITLE
Fix Battery Power using unsigned int (X1 Hybrid Gen4)

### DIFF
--- a/solax/inverters/x1_hybrid_gen4.py
+++ b/solax/inverters/x1_hybrid_gen4.py
@@ -49,7 +49,7 @@ class X1HybridGen4(Inverter):
             "On-grid daily yield": (13, DailyTotal(Units.KWH), div10),
             "Battery voltage": (14, Units.V, div100),
             "Battery current": (15, Units.A, div100),
-            "Battery power": (16, Units.W),
+            "Battery power": (16, Units.W, to_signed),
             "Battery temperature": (17, Units.C),
             "Battery SoC": (18, Units.PERCENT),
             "Inverter Temperature": (26, Units.C),


### PR DESCRIPTION
Similar to https://github.com/squishykid/solax/pull/152, but for battery power.
I had a workarounds for both in my HomeAssistant for a very long time now, this will finally allow me to remove hacks for both powers.

As explained in https://github.com/nazar-pc/solax-local-api-docs this likely affects more units in various inverters, but this it the value I cared and had a hack for in HomeAssistant.