### PR TITLE
fix: improve schema validation so it succeeds for qvolt_hyb_g3_3p inverter

### DIFF
--- a/solax/inverters/qvolt_hyb_g3_3p.py
+++ b/solax/inverters/qvolt_hyb_g3_3p.py
@@ -55,7 +55,7 @@ class QVOLTHYBG33P(Inverter):
             vol.Required("data"): vol.Schema(
                 vol.All(
                     [vol.Coerce(float)],
-                    vol.Length(min=200, max=200),
+                    vol.Length(min=200, max=400),
                 )
             ),
             vol.Required("information"): vol.Schema(


### PR DESCRIPTION
Hi,
I am using this lib now for more than a year and its works well. However, this fix i did here is required to get a successful data validation. I get a validation error when I do not apply it. I just tried it again with the latest master and same problem so here is now a PR to resolve this issue upstream.
Cheers