### PR TITLE
Fix X1 Hybrid Gen4 support with new firmware

### DIFF
--- a/solax/inverters/x1_hybrid_gen4.py
+++ b/solax/inverters/x1_hybrid_gen4.py
@@ -19,7 +19,7 @@ class X1HybridGen4(Inverter):
             vol.Required("data"): vol.Schema(
                 vol.All(
                     [vol.Coerce(float)],
-                    vol.Length(min=200, max=200),
+                    vol.Length(min=200, max=300),
                 )
             ),
             vol.Required("information"): vol.Schema(vol.All(vol.Length(min=9, max=10))),


### PR DESCRIPTION
Fixes https://github.com/squishykid/solax/issues/161, new firmware just has a bunch more zeroes on this inverter.
The whole approach with counting those is flawed though in my opinion judging by recent PRs. Maybe minimum is okay, but maximum clearly can change in newer firmwares.