### PR TITLE
Partially reverted b2a9ac5 - missing last_reset

### DIFF
--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -118,8 +118,10 @@ class X3HybridG4(Inverter):
             "PV Energy total": (pack_u16(80, 81), Total(Units.KWH), div10),
             "EPS Energy total": (pack_u16(83, 84), Total(Units.KWH), div10),
             "EPS Energy today": (85, DailyTotal(Units.KWH), div10),
-            "Feed-in Energy today": (pack_u16(90, 91), DailyTotal(Units.KWH), div100),
-            "Consumed Energy today": (pack_u16(92, 93), DailyTotal(Units.KWH), div100),
+            #TODO: Partially reverting b2a9ac5 until last_reset is fixed in
+            # HA core - closed PR https://github.com/home-assistant/core/pull/114743
+            "Feed-in Energy today": (pack_u16(90, 91), Total(Units.KWH), div100),
+            "Consumed Energy today": (pack_u16(92, 93), Total(Units.KWH), div100),
             "Feed-in Energy total": (pack_u16(86, 87), Total(Units.KWH), div100),
             "Consumed Energy total": (pack_u16(88, 89), Total(Units.KWH), div100),
             "Battery Remaining Capacity": (103, Units.PERCENT),

--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -118,7 +118,7 @@ class X3HybridG4(Inverter):
             "PV Energy total": (pack_u16(80, 81), Total(Units.KWH), div10),
             "EPS Energy total": (pack_u16(83, 84), Total(Units.KWH), div10),
             "EPS Energy today": (85, DailyTotal(Units.KWH), div10),
-            #TODO: Partially reverting b2a9ac5 until last_reset is fixed in
+            # Partially reverting b2a9ac5 until last_reset is fixed in
             # HA core - closed PR https://github.com/home-assistant/core/pull/114743
             "Feed-in Energy today": (pack_u16(90, 91), Total(Units.KWH), div100),
             "Consumed Energy today": (pack_u16(92, 93), Total(Units.KWH), div100),


### PR DESCRIPTION
Hi @squishykid I'm afraid I need to partially revert that recent change...

As last_reset is missing from solax daily_totals in ha-core integration, b2a9ac5 needed to be partially reversed as it makes consumed and fed in daily totals unusable.

 - reverted consumed and feed in daily total to Total class

~~I still think that these should be `DailyTotal`~~ [1], however right now, as `DailyTotal` they end up being simple `measurement` without `last_reset` set - and this makes them unusable in energy dashboard, even breaking it completely - to the point when user is no longer able to reconfigure it to remove them.

This should be fixed by https://github.com/home-assistant/core/pull/114743 which was closed for now by @frenck as it got stale...

Fix for the previously mentioned energy dashboard issue is to set their `state_class` in HA developer tools back to `total_increasing` and quickly enter edit mode of energy dashboard to delete them from configuration.

[1] https://developers.home-assistant.io/blog/2021/08/16/state_class_total/ - in this context measuremednt for a daily reset total sensor is no longer valid, and we should switch to total increasing.