### PR TITLE
Fix unique IDs error for battery_mode on X3hybridG4

### DIFF
--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -129,7 +129,7 @@ class X3HybridG4(Inverter):
                 Measurement(Units.KWH, storage=True),
                 div10,
             ),
-            "Battery mode": (168, Units.NONE),
+            # "Battery mode": (168, Units.NONE), # Only use the index once due to HA uids
             "Battery mode text": (168, Units.NONE, X3HybridG4._decode_battery_mode),
             "Battery Voltage": (pack_u16(169, 170), Units.V, div100),
         }

--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -130,7 +130,7 @@ class X3HybridG4(Inverter):
                 div10,
             ),
             # "Battery mode": (168, Units.NONE), # Only use the index once due to HA uids
-            "Battery mode text": (168, Units.NONE, X3HybridG4._decode_battery_mode),
+            "Battery mode": (168, Units.NONE, X3HybridG4._decode_battery_mode),
             "Battery Voltage": (pack_u16(169, 170), Units.V, div100),
         }
 

--- a/tests/samples/expected_values.py
+++ b/tests/samples/expected_values.py
@@ -306,7 +306,6 @@ X3_HYBRID_G4_VALUES = {
     "Battery Remaining Capacity": 30.0,
     "Battery Temperature": 22.0,
     "Battery Remaining Energy": 3.3,
-    "Battery mode": 0.0,
     "Battery mode text": "Self Use Mode",
     "Battery Voltage": 234.6,
 }

--- a/tests/samples/expected_values.py
+++ b/tests/samples/expected_values.py
@@ -306,7 +306,7 @@ X3_HYBRID_G4_VALUES = {
     "Battery Remaining Capacity": 30.0,
     "Battery Temperature": 22.0,
     "Battery Remaining Energy": 3.3,
-    "Battery mode text": "Self Use Mode",
+    "Battery mode": "Self Use Mode",
     "Battery Voltage": 234.6,
 }
 


### PR DESCRIPTION
Removed numerical "Battery mode" in favor of decoded version, fixing `Platform solax does not generate unique IDs. ID SRUJ233UF6-168 already exists - ignoring sensor.solax_battery_mode` error in homeassistant.