### PR TITLE
Fix X3 Hybrid G4 with PocketWiFi V2 not working via LAN

### DIFF
--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -27,7 +27,7 @@ class X3HybridG4(Inverter):
             vol.Required("data"): vol.Schema(
                 vol.All(
                     [vol.Coerce(float)],
-                    vol.Length(min=300, max=300),
+                    vol.Length(min=200, max=300),
                 )
             ),
             vol.Required("information"): vol.Schema(
@@ -39,7 +39,12 @@ class X3HybridG4(Inverter):
 
     @classmethod
     def build_all_variants(cls, host, port, pwd=""):
-        return [cls._build(host, port, pwd, False)]
+        versions = [cls._build(host, port, pwd, False)]
+        for inverter in versions:
+            inverter.http_client = inverter.http_client.with_headers(
+                {"X-Forwarded-For": "5.8.8.8"}
+            )
+        return versions
 
     @classmethod
     def _decode_run_mode(cls, run_mode):

--- a/solax/units.py
+++ b/solax/units.py
@@ -1,4 +1,4 @@
-""" Units and different measurement types"""
+"""Units and different measurement types"""
 
 from enum import Enum
 from typing import NamedTuple, Union


### PR DESCRIPTION
It would only work when connected directly to the PocketWiFi AP, since the V2 requires an X-Forwarded-For: header.

I have tested locally both with discovery and direct access and the data is populated correctly.

Fixes #188 