### PR TITLE
Fix X1G4Series schema to support 300 data point responses

### DIFF
--- a/solax/inverters/x1_g4_series.py
+++ b/solax/inverters/x1_g4_series.py
@@ -26,7 +26,13 @@ class X1G4Series(Inverter):
             ): str,
             vol.Required("ver"): str,
             vol.Required("data"): vol.Schema(
-                vol.All([vol.Coerce(float)], vol.Length(min=100, max=100))
+                vol.All(
+                    [vol.Coerce(float)],
+                    vol.Any(
+                        vol.Length(min=100, max=100),
+                        vol.Length(min=300, max=300),
+                    ),
+                )
             ),
             vol.Required("information"): vol.Schema(
                 vol.All(vol.Length(min=10, max=10))


### PR DESCRIPTION
- Update X1G4Series schema validation to accept both 100 and 300 data points
- Uses vol.Any to support multiple response formats similar to other inverters
- Fixes compatibility with newer X1-Boost inverters returning 300 data points
- Follows existing patterns used in x1_boost.py and other multi-format inverters