### PR TITLE
Add Grid TOT Power to inverter data mapping

### DIFF
--- a/solax/inverters/x3_hybrid_g4.py
+++ b/solax/inverters/x3_hybrid_g4.py
@@ -83,6 +83,7 @@ class X3HybridG4(Inverter):
             "Grid 1 Power": (6, Units.W, to_signed),
             "Grid 2 Power": (7, Units.W, to_signed),
             "Grid 3 Power": (8, Units.W, to_signed),
+            "Grid TOT Power": (9, Units.W, to_signed),
             "PV1 Voltage": (10, Units.V, div10),
             "PV2 Voltage": (11, Units.V, div10),
             "PV1 Current": (12, Units.A, div10),


### PR DESCRIPTION
the 9th position of the [DATA] set is the total of the previous three (6th 7th and 8th. In this way you have the totale power of the inverter, without having to do an helper