### PR TITLE
Fix X1G4Series schema to support 300 data point responses

### DIFF
--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -91,7 +91,7 @@ class Inverter:
         for name, mapping in cls.response_decoder().items():
             unit = Measurement(Units.NONE)
 
-            (idx, unit_or_measurement, *_) = mapping
+            idx, unit_or_measurement, *_ = mapping
 
             if isinstance(unit_or_measurement, Units):
                 unit = Measurement(unit_or_measurement)

--- a/solax/inverters/x1_g4_series.py
+++ b/solax/inverters/x1_g4_series.py
@@ -26,7 +26,13 @@ class X1G4Series(Inverter):
             ): str,
             vol.Required("ver"): str,
             vol.Required("data"): vol.Schema(
-                vol.All([vol.Coerce(float)], vol.Length(min=100, max=100))
+                vol.All(
+                    [vol.Coerce(float)],
+                    vol.Any(
+                        vol.Length(min=100, max=100),
+                        vol.Length(min=300, max=300),
+                    ),
+                )
             ),
             vol.Required("information"): vol.Schema(
                 vol.All(vol.Length(min=10, max=10))

--- a/solax/response_parser.py
+++ b/solax/response_parser.py
@@ -46,7 +46,7 @@ _KEY_VER = "ver"
 _KEY_TYPE = "type"
 
 
-GenericResponseSchema = vol.All(
+GENERIC_RESPONSE_SCHEMA = vol.All(
     vol.Schema({vol.Required(_KEY_SERIAL): str}, extra=vol.ALLOW_EXTRA),
     vol.Any(
         vol.Schema({vol.Required(_KEY_VERSION): str}, extra=vol.ALLOW_EXTRA),
@@ -77,7 +77,7 @@ class ResponseParser:
         dongle_serial_number_getter: Callable[[Dict[str, Any]], Optional[str]],
         inverter_serial_number_getter: Callable[[Dict[str, Any]], Optional[str]],
     ) -> None:
-        self.schema = vol.And(GenericResponseSchema, schema)
+        self.schema = vol.And(GENERIC_RESPONSE_SCHEMA, schema)
         self.response_decoder = decoder
         self.dongle_serial_number_getter = dongle_serial_number_getter
         self.inverter_serial_number_getter = inverter_serial_number_getter
@@ -95,7 +95,7 @@ class ResponseParser:
         Return map of functions to be applied to each sensor value
         """
         for name, mapping in self.response_decoder.items():
-            (_, _, *processors) = mapping
+            _, _, *processors = mapping
             for processor in processors:
                 yield name, processor
 


### PR DESCRIPTION
- Update X1G4Series schema validation to accept both 100 and 300 data points
- Uses vol.Any to support multiple response formats similar to other inverters
- Fixes compatibility with newer X1-Boost inverters returning 300 data points
- Follows existing patterns used in x1_boost.py and other multi-format inverters