### PR TITLE
Fix broken inverter detection

### DIFF
--- a/solax/inverter.py
+++ b/solax/inverter.py
@@ -91,7 +91,7 @@ class Inverter:
         for name, mapping in cls.response_decoder().items():
             unit = Measurement(Units.NONE)
 
-            (idx, unit_or_measurement, *_) = mapping
+            idx, unit_or_measurement, *_ = mapping
 
             if isinstance(unit_or_measurement, Units):
                 unit = Measurement(unit_or_measurement)

--- a/solax/inverters/x1_lite_lv.py
+++ b/solax/inverters/x1_lite_lv.py
@@ -11,7 +11,7 @@ class X1LiteLV(Inverter):
     # pylint: disable=duplicate-code
     _schema = vol.Schema(
         {
-            vol.Required("type"): int,
+            vol.Required("type"): vol.All(int, 103),
             vol.Required("sn"): str,
             vol.Required("ver"): str,
             vol.Required("data"): vol.Schema(

--- a/solax/response_parser.py
+++ b/solax/response_parser.py
@@ -46,7 +46,7 @@ _KEY_VER = "ver"
 _KEY_TYPE = "type"
 
 
-GenericResponseSchema = vol.All(
+GENERIC_RESPONSE_SCHEMA = vol.All(
     vol.Schema({vol.Required(_KEY_SERIAL): str}, extra=vol.ALLOW_EXTRA),
     vol.Any(
         vol.Schema({vol.Required(_KEY_VERSION): str}, extra=vol.ALLOW_EXTRA),
@@ -77,7 +77,7 @@ class ResponseParser:
         dongle_serial_number_getter: Callable[[Dict[str, Any]], Optional[str]],
         inverter_serial_number_getter: Callable[[Dict[str, Any]], Optional[str]],
     ) -> None:
-        self.schema = vol.And(GenericResponseSchema, schema)
+        self.schema = vol.And(GENERIC_RESPONSE_SCHEMA, schema)
         self.response_decoder = decoder
         self.dongle_serial_number_getter = dongle_serial_number_getter
         self.inverter_serial_number_getter = inverter_serial_number_getter
@@ -95,7 +95,7 @@ class ResponseParser:
         Return map of functions to be applied to each sensor value
         """
         for name, mapping in self.response_decoder.items():
-            (_, _, *processors) = mapping
+            _, _, *processors = mapping
             for processor in processors:
                 yield name, processor
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -152,7 +152,7 @@ async def test_discovery_not_first_completed_after_staggering(
     inverters = await solax.discover(
         *conn,
         inverters=[DelayedX1Boost, DelayedFailedX1Boost],
-        return_when=asyncio.FIRST_EXCEPTION
+        return_when=asyncio.FIRST_EXCEPTION,
     )
     assert DelayedX1Boost in {type(inverter) for inverter in inverters}
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -72,7 +72,7 @@ async def test_discovery_first_completed_returns_expected_model_for_overlapping_
         return_when=asyncio.FIRST_COMPLETED,
     )
 
-    assert type(inverter) is inverter_class
+    assert isinstance(inverter, inverter_class)
 
 
 @pytest.mark.asyncio

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -35,38 +35,44 @@ async def test_discovery(inverters_fixture):
 
 
 @pytest.mark.asyncio
-async def test_discovery_x1_hybrid_gen4_is_not_misdetected_as_x1_lite_lv(inverters_fixture):
-    conn, inverter_class, _ = inverters_fixture
-
-    if inverter_class is not X1HybridGen4:
-        pytest.skip()
-
-    inverters = await solax.discover(
-        *conn,
-        inverters=[X1HybridGen4, X1LiteLV],
-        return_when=asyncio.ALL_COMPLETED,
-    )
-    discovered_types = {type(inverter) for inverter in inverters}
-
-    assert discovered_types == {X1HybridGen4}
-
-
-@pytest.mark.asyncio
-async def test_discovery_first_completed_prefers_correct_model_for_x1_hybrid_gen4(
+async def test_discovery_returns_only_expected_model_for_overlapping_schemas(
     inverters_fixture,
 ):
     conn, inverter_class, _ = inverters_fixture
 
-    if inverter_class is not X1HybridGen4:
+    overlapping_inverters = {X1HybridGen4, X1LiteLV}
+
+    if inverter_class not in overlapping_inverters:
+        pytest.skip()
+
+    inverters = await solax.discover(
+        *conn,
+        inverters=list(overlapping_inverters),
+        return_when=asyncio.ALL_COMPLETED,
+    )
+    discovered_types = {type(inverter) for inverter in inverters}
+
+    assert discovered_types == {inverter_class}
+
+
+@pytest.mark.asyncio
+async def test_discovery_first_completed_returns_expected_model_for_overlapping_schemas(
+    inverters_fixture,
+):
+    conn, inverter_class, _ = inverters_fixture
+
+    overlapping_inverters = [X1LiteLV, X1HybridGen4]
+
+    if inverter_class not in set(overlapping_inverters):
         pytest.skip()
 
     inverter = await solax.discover(
         *conn,
-        inverters=[X1LiteLV, X1HybridGen4],
+        inverters=overlapping_inverters,
         return_when=asyncio.FIRST_COMPLETED,
     )
 
-    assert type(inverter) is X1HybridGen4
+    assert type(inverter) is inverter_class
 
 
 @pytest.mark.asyncio

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -6,7 +6,7 @@ import solax
 from solax import InverterResponse
 from solax.discovery import REGISTRY, DiscoveryError
 from solax.inverter import InverterError
-from solax.inverters import X1Boost
+from solax.inverters import X1Boost, X1HybridGen4, X1LiteLV
 
 
 class DelayedX1Boost(X1Boost):
@@ -32,6 +32,41 @@ async def test_discovery(inverters_fixture):
             data = await inverter.get_data()
             assert "X" * 7 in (data.inverter_serial_number or "X" * 7)
             assert data.serial_number == data.dongle_serial_number
+
+
+@pytest.mark.asyncio
+async def test_discovery_x1_hybrid_gen4_is_not_misdetected_as_x1_lite_lv(inverters_fixture):
+    conn, inverter_class, _ = inverters_fixture
+
+    if inverter_class is not X1HybridGen4:
+        pytest.skip()
+
+    inverters = await solax.discover(
+        *conn,
+        inverters=[X1HybridGen4, X1LiteLV],
+        return_when=asyncio.ALL_COMPLETED,
+    )
+    discovered_types = {type(inverter) for inverter in inverters}
+
+    assert discovered_types == {X1HybridGen4}
+
+
+@pytest.mark.asyncio
+async def test_discovery_first_completed_prefers_correct_model_for_x1_hybrid_gen4(
+    inverters_fixture,
+):
+    conn, inverter_class, _ = inverters_fixture
+
+    if inverter_class is not X1HybridGen4:
+        pytest.skip()
+
+    inverter = await solax.discover(
+        *conn,
+        inverters=[X1LiteLV, X1HybridGen4],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    assert type(inverter) is X1HybridGen4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
v3.2.4 introduced a breaking change where some inverter types were incorrectly detected as X1_Lite_LV.

This change adds an extra check to the X1_Lite_LV type detection so that it only matches when the type is 103. I'm not sure if this will break the X1_Lite_LV inverters as there's only one example payload, but it certainly fixes my own inverter's detection.